### PR TITLE
chore: use terminology

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,9 +9,9 @@
 A browser extension that stores and uses the identities and credentials of the user.
 When the user visits a webpage, the extension injects its API into this webpage.
 
-### dApp
+### dApp – Decentralized application
 
-Decentralized application – a website that can interact with the extension via the API it exposes.
+A website that can interact with the extension via the API it exposes.
 The example dApps in this specification are Attester and Verifier.
 
 

--- a/readme.md
+++ b/readme.md
@@ -292,7 +292,7 @@ so the extension SHOULD provide means to cancel an individual step, while the dA
 The user also always has the last resort of simply closing the dApp page.
 
 The extension SHOULD report the closure of the popup (by the user or because of the switch to another app)
-as a cancellation, not an error.
+as a rejection, not an error.
 
 On receiving an error or a rejection from the dApp, the extension SHOULD offer options to retry and to cancel.
 On receiving an error or a rejection from the extension, the dApp SHOULD highlight the option to cancel the flow
@@ -307,7 +307,7 @@ Okay, it did not, so I cannot provide what they want, but I do not want to cance
 In a different scenario, the extension MAY try to detect the trustworthiness of the dApp
 by requesting from it some credentials, and the dApp MAY reject these requests.
 The extension MAY use the results of this exchange to indicate to the user its level of confidence
-in the trustworthiness of the dApp, for example, as the browsers do for SSL and EV certificates.
+in the trustworthiness of the dApp, for example, as the browsers do for TLS certificates.
 
 ```typescript
 interface Rejection {


### PR DESCRIPTION


* The extension can report rejection or error, but not cancellation.
* SSL is the old name for TLS.
* EV Certificates are not handled differently than DV certificates. No need to
make the distinction.
